### PR TITLE
Custom revel.TypeBinder for bson.ObjectIds

### DIFF
--- a/revmgo.go
+++ b/revmgo.go
@@ -37,7 +37,8 @@ func AppInit() {
 	}
 
 	// register the custom bson.ObjectId binder
-	revel.TypeBinders[reflect.TypeOf(bson.ObjectId{})] = ObjectIdBinder
+	objId := bson.NewObjectId()
+	revel.TypeBinders[reflect.TypeOf(objId)] = ObjectIdBinder
 }
 
 func ControllerInit() {


### PR DESCRIPTION
A bit polished.
- removed the commented debug prints
- also checked if reverse routing works
